### PR TITLE
스터디 가입, 초대, 수정, 승인 기능구현

### DIFF
--- a/src/main/java/com/baeker/baeker/member/MemberController.java
+++ b/src/main/java/com/baeker/baeker/member/MemberController.java
@@ -8,6 +8,8 @@ import com.baeker.baeker.member.form.MemberModifyForm;
 import com.baeker.baeker.myStudy.MyStudy;
 import com.baeker.baeker.myStudy.MyStudyService;
 import com.baeker.baeker.myStudy.form.MyStudyInviteForm;
+import com.baeker.baeker.myStudy.form.MyStudyJoinForm;
+import com.baeker.baeker.myStudy.form.MyStudyModfyMsgForm;
 import com.baeker.baeker.study.Study;
 import com.baeker.baeker.study.StudyService;
 import jakarta.validation.Valid;
@@ -28,6 +30,7 @@ import java.util.List;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MyStudyService myStudyService;
     private final Rq rq;
 
 
@@ -75,11 +78,17 @@ public class MemberController {
     @PreAuthorize("isAuthenticated()")
     public String myProfile(
             @PathVariable String list,
+            MyStudyModfyMsgForm form,
             Model model
     ) {
         Member member = rq.getMember();
         log.info("내 프로필 요청 확인 member = {}", member.toString());
 
+        List<MyStudy> myStudies = myStudyService.statusMember(member);
+        List<MyStudy> pending = myStudyService.statusNotMember(member);
+
+        model.addAttribute("myStudies", myStudies);
+        model.addAttribute("pending", pending);
         model.addAttribute("list", list);
         log.info("내 프로필 응답 완료");
         return "member/profile";

--- a/src/main/java/com/baeker/baeker/member/MemberService.java
+++ b/src/main/java/com/baeker/baeker/member/MemberService.java
@@ -173,6 +173,17 @@ public class MemberService {
         return RsData.of("S-1", "수정이 완료되었습니다.", member);
     }
 
+    //-- 스터디 가입 여부 확인 --//
+    public boolean isMyStudy(Member member, Study study) {
+        List<MyStudy> myStudies = member.getMyStudies();
+
+        for (MyStudy myStudy : myStudies)
+            if (!myStudy.getStudy().equals(study))
+                return false;
+
+        return true;
+    }
+
 
     //-- 1~999 랜덤숫자 생성 --//
     public List<Integer> random() {

--- a/src/main/java/com/baeker/baeker/myStudy/MyStudy.java
+++ b/src/main/java/com/baeker/baeker/myStudy/MyStudy.java
@@ -102,4 +102,11 @@ public class MyStudy {
         this.msg = null;
         return baekJoon;
     }
+
+    // 초대, 가입 요청 메시지 변경 //
+    protected MyStudy modifyMsg(String msg) {
+        return this.toBuilder()
+                .msg(msg)
+                .build();
+    }
 }

--- a/src/main/java/com/baeker/baeker/myStudy/MyStudyController.java
+++ b/src/main/java/com/baeker/baeker/myStudy/MyStudyController.java
@@ -5,6 +5,7 @@ import com.baeker.baeker.base.request.RsData;
 import com.baeker.baeker.member.Member;
 import com.baeker.baeker.member.MemberService;
 import com.baeker.baeker.myStudy.form.MyStudyInviteForm;
+import com.baeker.baeker.myStudy.form.MyStudyJoinForm;
 import com.baeker.baeker.study.Study;
 import com.baeker.baeker.study.StudyService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,32 @@ public class MyStudyController {
     private final Rq rq;
 
     //-- 가입 신청하기 --//
+    @PostMapping("join/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public String join(
+            @PathVariable Long id,
+            MyStudyJoinForm form
+    ){
+        log.info("스터디 가입 요청 확인 study id = {}", id);
+
+        Member member = rq.getMember();
+        RsData<Study> studyRs = studyService.getStudy(id);
+
+        if (studyRs.isFail()) {
+            log.info("study 조회 실패 error = {}", studyRs.getMsg());
+            return rq.historyBack(studyRs.getMsg());
+        }
+
+        RsData<MyStudy> joinRs = myStudyService.join(member, studyRs.getData(), form.getMsg());
+
+        if (joinRs.isFail()) {
+            log.info("스터디 가입 요청 실패 error = {}", joinRs.getMsg());
+            return rq.historyBack(joinRs.getMsg());
+        }
+
+        log.info("스터디 가입 성공 가입 메시지 = {}", joinRs.getData().getMsg());
+        return rq.redirectWithMsg("/study/detail/req/" + studyRs.getData().getId(), joinRs.getMsg());
+    }
 
     //-- 스터디로 초대하기 --//
     @PostMapping("invite/{id}")
@@ -62,6 +89,6 @@ public class MyStudyController {
         }
 
         log.info("초대 성공 초대 메시지 = {}", form.getMsg());
-        return rq.redirectWithMsg("/study/detail/" + studyRs.getData().getId(), inviteRs.getMsg());
+        return rq.redirectWithMsg("/study/detail/req/" + studyRs.getData().getId(), inviteRs.getMsg());
     }
 }

--- a/src/main/java/com/baeker/baeker/myStudy/MyStudyController.java
+++ b/src/main/java/com/baeker/baeker/myStudy/MyStudyController.java
@@ -16,6 +16,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -36,7 +37,7 @@ public class MyStudyController {
     public String join(
             @PathVariable Long id,
             MyStudyJoinForm form
-    ){
+    ) {
         log.info("스터디 가입 요청 확인 study id = {}", id);
 
         Member member = rq.getMember();
@@ -55,7 +56,7 @@ public class MyStudyController {
         }
 
         log.info("스터디 가입 성공 가입 메시지 = {}", joinRs.getData().getMsg());
-        return rq.redirectWithMsg("/study/detail/req/" + studyRs.getData().getId(), joinRs.getMsg());
+        return rq.redirectWithMsg("/member/profile/join", joinRs.getMsg());
     }
 
     //-- 스터디로 초대하기 --//
@@ -90,5 +91,25 @@ public class MyStudyController {
 
         log.info("초대 성공 초대 메시지 = {}", form.getMsg());
         return rq.redirectWithMsg("/study/detail/req/" + studyRs.getData().getId(), inviteRs.getMsg());
+    }
+
+    //-- 초대, 가입 요청 매시지 수정 --//
+    @PostMapping("/modify/msg/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public String modifyMsg(
+            @PathVariable Long id,
+            @RequestParam String msg
+    ) {
+        log.info("메시지 수정 요청 확인 my study id = {}", id);
+        RsData<MyStudy> myStudyRs = myStudyService.getMyStudy(id);
+
+        if (myStudyRs.isFail()) {
+            log.info("스터디 조회 실패 error = {}", myStudyRs.getMsg());
+            return rq.historyBack(myStudyRs.getMsg());
+        }
+
+        MyStudy myStudy = myStudyRs.getData();
+        MyStudy modifyMyStudy = myStudyService.modifyMsg(myStudy, msg);
+        return rq.redirectWithMsg("/member/profile/join", "메시지 변경 완료");
     }
 }

--- a/src/main/java/com/baeker/baeker/myStudy/MyStudyController.java
+++ b/src/main/java/com/baeker/baeker/myStudy/MyStudyController.java
@@ -177,6 +177,6 @@ public class MyStudyController {
         }
 
         log.info("정식 스터디 원으로 승인 완료");
-        return rq.redirectWithMsg("/study/detaile/member/" + myStudy.getStudy().getId(), acceptRs.getMsg());
+        return rq.redirectWithMsg("/study/detail/member/" + myStudy.getStudy().getId(), acceptRs.getMsg());
     }
 }

--- a/src/main/java/com/baeker/baeker/myStudy/MyStudyController.java
+++ b/src/main/java/com/baeker/baeker/myStudy/MyStudyController.java
@@ -110,6 +110,6 @@ public class MyStudyController {
 
         MyStudy myStudy = myStudyRs.getData();
         MyStudy modifyMyStudy = myStudyService.modifyMsg(myStudy, msg);
-        return rq.redirectWithMsg("/member/profile/join", "메시지 변경 완료");
+        return rq.historyBack("메시지 변경 완료");
     }
 }

--- a/src/main/java/com/baeker/baeker/myStudy/MyStudyService.java
+++ b/src/main/java/com/baeker/baeker/myStudy/MyStudyService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -115,5 +116,37 @@ public class MyStudyService {
                 return RsData.of("F-1", "이미 가입한 스터디입니다.");
         }
         return RsData.of("S-1", "성공");
+    }
+
+    //-- member 등급인 my study 만 조회 --//
+    public List<MyStudy> statusMember(Member member) {
+        List<MyStudy> myStudies = new ArrayList<>();
+        List<MyStudy> myStudyList = member.getMyStudies();
+
+        for (MyStudy myStudy : myStudyList)
+            if (myStudy.getStatus().equals(StudyStatus.MEMBER))
+                myStudies.add(myStudy);
+
+        return myStudies;
+    }
+
+
+    //-- member 등급이 아닌 my study 조회 --//
+    public List<MyStudy> statusNotMember(Member member) {
+        List<MyStudy> pending = new ArrayList<>();
+        List<MyStudy> myStudies = member.getMyStudies();
+
+        for (MyStudy myStudy : myStudies)
+            if (!myStudy.getStatus().equals(StudyStatus.MEMBER))
+                pending.add(myStudy);
+
+        return pending;
+    }
+
+    //-- 초대, 가입 요청 메시지 변경 --//
+    @Transactional
+    public MyStudy modifyMsg(MyStudy myStudy, String msg) {
+        MyStudy modify = myStudy.modifyMsg(msg);
+        return myStudyRepository.save(modify);
     }
 }

--- a/src/main/java/com/baeker/baeker/myStudy/MyStudyService.java
+++ b/src/main/java/com/baeker/baeker/myStudy/MyStudyService.java
@@ -130,11 +130,33 @@ public class MyStudyService {
         return myStudies;
     }
 
+    public List<MyStudy> statusMember(Study study) {
+        List<MyStudy> myStudies = new ArrayList<>();
+        List<MyStudy> myStudyList = study.getMyStudies();
+
+        for (MyStudy myStudy : myStudyList)
+            if (myStudy.getStatus().equals(StudyStatus.MEMBER))
+                myStudies.add(myStudy);
+
+        return myStudies;
+    }
+
 
     //-- member 등급이 아닌 my study 조회 --//
     public List<MyStudy> statusNotMember(Member member) {
         List<MyStudy> pending = new ArrayList<>();
         List<MyStudy> myStudies = member.getMyStudies();
+
+        for (MyStudy myStudy : myStudies)
+            if (!myStudy.getStatus().equals(StudyStatus.MEMBER))
+                pending.add(myStudy);
+
+        return pending;
+    }
+
+    public List<MyStudy> statusNotMember(Study study) {
+        List<MyStudy> pending = new ArrayList<>();
+        List<MyStudy> myStudies = study.getMyStudies();
 
         for (MyStudy myStudy : myStudies)
             if (!myStudy.getStatus().equals(StudyStatus.MEMBER))

--- a/src/main/java/com/baeker/baeker/myStudy/StudyStatus.java
+++ b/src/main/java/com/baeker/baeker/myStudy/StudyStatus.java
@@ -1,5 +1,7 @@
 package com.baeker.baeker.myStudy;
 
+import org.springframework.stereotype.Component;
+
 public enum StudyStatus {
     MEMBER, PENDING, INVITING
 }

--- a/src/main/java/com/baeker/baeker/myStudy/form/MyStudyJoinForm.java
+++ b/src/main/java/com/baeker/baeker/myStudy/form/MyStudyJoinForm.java
@@ -1,0 +1,13 @@
+package com.baeker.baeker.myStudy.form;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MyStudyJoinForm {
+
+    @Size(max = 40)
+    private String msg;
+}

--- a/src/main/java/com/baeker/baeker/myStudy/form/MyStudyModfyMsgForm.java
+++ b/src/main/java/com/baeker/baeker/myStudy/form/MyStudyModfyMsgForm.java
@@ -1,0 +1,13 @@
+package com.baeker.baeker.myStudy.form;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MyStudyModfyMsgForm {
+
+    @Size(max = 40)
+    private String msg;
+}

--- a/src/main/java/com/baeker/baeker/solvedApi/ApiScheduler.java
+++ b/src/main/java/com/baeker/baeker/solvedApi/ApiScheduler.java
@@ -29,7 +29,7 @@ public class ApiScheduler {
      * 티어 체크 후 Study
      */
 
-//    @Scheduled(fixedRate = 1000)
+    @Scheduled(fixedRate = 1000)
     public void checkStudyRule() throws IOException, ParseException {
         log.info("스케줄러 실행");
         RsData<List<Member>> memberList = memberService.getAll();

--- a/src/main/java/com/baeker/baeker/solvedApi/ApiScheduler.java
+++ b/src/main/java/com/baeker/baeker/solvedApi/ApiScheduler.java
@@ -29,7 +29,7 @@ public class ApiScheduler {
      * 티어 체크 후 Study
      */
 
-    @Scheduled(fixedRate = 1000)
+//    @Scheduled(fixedRate = 1000)
     public void checkStudyRule() throws IOException, ParseException {
         log.info("스케줄러 실행");
         RsData<List<Member>> memberList = memberService.getAll();

--- a/src/main/java/com/baeker/baeker/study/StudyController.java
+++ b/src/main/java/com/baeker/baeker/study/StudyController.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @Controller
 @RequestMapping("/study")
@@ -81,6 +83,11 @@ public class StudyController {
             isMyStudy = memberService.isMyStudy(member, studyRs.getData());
         }
 
+        List<MyStudy> myStudies = myStudyService.statusMember(studyRs.getData());
+        List<MyStudy> pending = myStudyService.statusNotMember(studyRs.getData());
+
+        model.addAttribute("myStudies", myStudies);
+        model.addAttribute("pending", pending);
         model.addAttribute("isMyStudy", isMyStudy);
         model.addAttribute("list", list);
         model.addAttribute("study", studyRs.getData());

--- a/src/main/java/com/baeker/baeker/study/StudyController.java
+++ b/src/main/java/com/baeker/baeker/study/StudyController.java
@@ -31,6 +31,7 @@ public class StudyController {
     @PreAuthorize("isAuthenticated()")
     public String createForm(StudyCreateForm form) {
         log.info("스터디 생성폼 요청 확인");
+        form.setCapacity(10);
         return "/study/create";
     }
 
@@ -52,7 +53,7 @@ public class StudyController {
         myStudyService.create(member, study);
 
         log.info("스터디 생성 완료 study name = {}", study.getName());
-        return rq.redirectWithMsg("/study/detail/" + study.getId(), "스터디 개설 완료!");
+        return rq.redirectWithMsg("/study/detail/rule/" + study.getId(), "스터디 개설 완료!");
     }
 
     //-- 스터디 상세 페이지 --//

--- a/src/main/java/com/baeker/baeker/study/StudyController.java
+++ b/src/main/java/com/baeker/baeker/study/StudyController.java
@@ -3,8 +3,10 @@ package com.baeker.baeker.study;
 import com.baeker.baeker.base.request.Rq;
 import com.baeker.baeker.base.request.RsData;
 import com.baeker.baeker.member.Member;
+import com.baeker.baeker.member.MemberService;
 import com.baeker.baeker.myStudy.MyStudy;
 import com.baeker.baeker.myStudy.MyStudyService;
+import com.baeker.baeker.myStudy.form.MyStudyJoinForm;
 import com.baeker.baeker.study.form.StudyCreateForm;
 import com.baeker.baeker.study.form.StudyModifyForm;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ public class StudyController {
 
     private final StudyService studyService;
     private final MyStudyService myStudyService;
+    private final MemberService memberService;
     private final Rq rq;
 
     //-- 스터디 생성 폼 --//
@@ -61,16 +64,24 @@ public class StudyController {
     public String detail(
             @PathVariable String list,
             @PathVariable Long id,
+            MyStudyJoinForm form,
             Model model
     ) {
         log.info("스터디 상세페이지 요청 확인 study id = {}", id);
         RsData<Study> studyRs = studyService.getStudy(id);
+        boolean isMyStudy = true;
 
         if (studyRs.isFail()) {
             log.info("존재하지 않는 id = {}", id);
-            return rq.historyBack(studyRs);
+            return rq.historyBack(studyRs.getMsg());
         }
 
+        if (rq.isLogin()) {
+            Member member = rq.getMember();
+            isMyStudy = memberService.isMyStudy(member, studyRs.getData());
+        }
+
+        model.addAttribute("isMyStudy", isMyStudy);
         model.addAttribute("list", list);
         model.addAttribute("study", studyRs.getData());
         log.info("상세페이지 응답 완료");
@@ -130,7 +141,7 @@ public class StudyController {
         log.info("스터디 수정 처리 요청 확인 id = {}", form.getId());
         RsData<Study> studyRs = studyService.getStudy(id);
 
-        if (studyRs.isFail()){
+        if (studyRs.isFail()) {
             log.info("존재하지 않는 id 입니다. id = {}", id);
             return rq.historyBack(studyRs.getMsg());
         }

--- a/src/main/java/com/baeker/baeker/study/form/StudyModifyForm.java
+++ b/src/main/java/com/baeker/baeker/study/form/StudyModifyForm.java
@@ -24,10 +24,4 @@ public class StudyModifyForm {
     @NotNull
     @Range(min = 2, max = 20)
     private Integer capacity;
-
-    public StudyModifyForm(String name, String about, Integer capacity) {
-        this.name = name;
-        this.about = about;
-        this.capacity = capacity;
-    }
 }

--- a/src/main/resources/templates/member/fragment/profile/join.html
+++ b/src/main/resources/templates/member/fragment/profile/join.html
@@ -9,7 +9,7 @@
         <th class="flex-grow">소개</th>
         <th>인원</th>
         <th>스터디장</th>
-        <th></th>
+        <th>상태</th>
     </tr>
     </thead>
     <tbody>
@@ -40,8 +40,8 @@
         </td>
         <td>
             <a class="link link-primary"
-               href="#my-modal-2">
-                상태
+               th:text="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}? '가입' : '초대'"
+               th:href="@{#my-modal-{id}(id=${myStudy.id})}">
             </a>
 
             <div th:replace="~{member/fragment/profile/pending :: pending(${myStudy})}"></div>

--- a/src/main/resources/templates/member/fragment/profile/join.html
+++ b/src/main/resources/templates/member/fragment/profile/join.html
@@ -1,5 +1,5 @@
-<table th:fragment="study(list, myStudies)"
-       th:if="${list eq 'study'}"
+<table th:fragment="join(list, pending)"
+       th:if="${list eq 'join'}"
        class="table w-full">
     <!-- head -->
     <thead>
@@ -9,12 +9,12 @@
         <th class="flex-grow">소개</th>
         <th>인원</th>
         <th>스터디장</th>
-        <th>랭킹</th>
+        <th></th>
     </tr>
     </thead>
     <tbody>
     <tr class="hover"
-        th:each="myStudy , loop : ${myStudies}"
+        th:each="myStudy , loop : ${pending}"
         th:object="${myStudy.study}">
 
         <th>
@@ -39,8 +39,12 @@
                th:href="@{/study/detail/{list}/{id}(list='rule', id=*{id})}"></a>
         </td>
         <td>
-            <a th:text="|0|"
-               th:href="@{/study/detail/{list}/{id}(list='rule', id=*{id})}"></a>
+            <a class="link link-primary"
+               href="#my-modal-2">
+                상태
+            </a>
+
+            <div th:replace="~{member/fragment/profile/pending :: pending(${myStudy})}"></div>
         </td>
     </tr>
 

--- a/src/main/resources/templates/member/fragment/profile/list.html
+++ b/src/main/resources/templates/member/fragment/profile/list.html
@@ -1,4 +1,4 @@
-<div th:fragment="list (list)"
+<div th:fragment="list (list, myStudies, pending)"
      class="overflow-x-auto w-[70%] mb-5">
 
   <div class="tabs flex justify-center mb-7">
@@ -17,11 +17,17 @@
          class="tab tab-bordered"
          th:classappend="${list == 'study'} ? 'tab-active' : ''">내 스터디</a>
 
+      <a href="/member/profile/join#list"
+         class="tab tab-bordered"
+         th:classappend="${list == 'join'} ? 'tab-active' : ''">가입 대기중</a>
+
     </div>
 
 
   </div>
 
-  <table th:replace="~{member/fragment/profile/study :: study(${list})}"></table>
+  <table th:replace="~{member/fragment/profile/study :: study(${list}, ${myStudies})}"></table>
+
+  <table th:replace="~{member/fragment/profile/join :: join(${list}, ${pending})}"></table>
 
 </div>

--- a/src/main/resources/templates/member/fragment/profile/pending.html
+++ b/src/main/resources/templates/member/fragment/profile/pending.html
@@ -1,0 +1,30 @@
+<div th:fragment="pending(myStudy)"
+     class="modal" id="my-modal-2">
+
+  <div class="modal-box">
+
+
+    <h3 th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
+        th:text="|${myStudy.study.name}에 가입 신청|"
+        class="font-bold text-lg"></h3>
+
+
+    <h3 th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING}"
+        th:text="|${myStudy.study.name}에서 초대|"
+        class="font-bold text-lg"></h3>
+
+    <form th:action="@{/my_study/modify/msg/{id}(id=${myStudy.id})}"
+          method="post" class="mt-5 mb-5 flex flex-col">
+
+
+      <textarea th:text="${myStudy.msg}" name="msg" placeholder="메시지 수정"
+                class="textarea textarea-ghost mb-5 mt-5 w-full"></textarea>
+
+
+      <button class="btn btn-primary">메시지 수정하기</button>
+
+      <a href="#" class="btn mt-4">취소</a>
+
+    </form>
+  </div>
+</div>

--- a/src/main/resources/templates/member/fragment/profile/pending.html
+++ b/src/main/resources/templates/member/fragment/profile/pending.html
@@ -1,30 +1,39 @@
 <div th:fragment="pending(myStudy)"
-     class="modal" id="my-modal-2">
+     th:id="'my-modal-' + ${myStudy.id}"
+     class="modal">
 
-  <div class="modal-box">
-
-
-    <h3 th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
-        th:text="|${myStudy.study.name}에 가입 신청|"
-        class="font-bold text-lg"></h3>
+    <div class="modal-box">
 
 
-    <h3 th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING}"
-        th:text="|${myStudy.study.name}에서 초대|"
-        class="font-bold text-lg"></h3>
+        <h3 th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
+            th:text="|${myStudy.study.name} 가입 신청 승인 대기|"
+            class="font-bold text-lg"></h3>
 
-    <form th:action="@{/my_study/modify/msg/{id}(id=${myStudy.id})}"
-          method="post" class="mt-5 mb-5 flex flex-col">
+
+        <h3 th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING}"
+            th:text="|${myStudy.study.name}에서 보낸 초대 메시지|"
+            class="font-bold text-lg"></h3>
+
+        <form th:action="@{/my_study/modify/msg/{id}(id=${myStudy.id})}"
+              method="post" class="mt-5 mb-5 flex flex-col">
 
 
       <textarea th:text="${myStudy.msg}" name="msg" placeholder="메시지 수정"
+                th:disabled="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING} ? 'disabled'"
                 class="textarea textarea-ghost mb-5 mt-5 w-full"></textarea>
 
 
-      <button class="btn btn-primary">메시지 수정하기</button>
+            <button th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
+                    class="btn btn-primary">메시지 수정하기
+            </button>
+        </form>
 
-      <a href="#" class="btn mt-4">취소</a>
+        <form th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING}"
+              th:action="@{/my_study/me/accept/{id}(id=${myStudy.id})}" method="post">
+            <button class="btn btn-primary mt-4 w-full" type="submit">초대 수락</button>
+        </form>
 
-    </form>
-  </div>
+        <a href="#" class="btn w-full">확인</a>
+
+    </div>
 </div>

--- a/src/main/resources/templates/member/profile.html
+++ b/src/main/resources/templates/member/profile.html
@@ -17,7 +17,7 @@
 
     <div class="w-full flex  justify-center">
 
-        <div th:replace="~{member/fragment/profile/list :: list(${list})}"></div>
+        <div th:replace="~{member/fragment/profile/list :: list(${list}, ${myStudies}, ${pending})}"></div>
 
 
     </div>

--- a/src/main/resources/templates/study/detail.html
+++ b/src/main/resources/templates/study/detail.html
@@ -10,7 +10,7 @@
 
         <div class="w-full flex justify-center mt-12">
 
-            <div th:replace="~{study/fragment/detail/list :: list(${study}, ${list})}"></div>
+            <div th:replace="~{study/fragment/detail/list :: list(${study}, ${list}, ${myStudies}, ${pending})}"></div>
         </div>
     </div>
 

--- a/src/main/resources/templates/study/detail.html
+++ b/src/main/resources/templates/study/detail.html
@@ -5,7 +5,7 @@
 <main layout:fragment="content" class="min-h-screen flex flex-col">
 
     <div class="flex flex-col justify-center">
-        <div th:replace="~{study/fragment/detail/profile :: profile(${study})}"></div>
+        <div th:replace="~{study/fragment/detail/profile :: profile(${study}, ${isMyStudy}, ${myStudyJoinForm})}"></div>
 
 
         <div class="w-full flex justify-center mt-12">

--- a/src/main/resources/templates/study/fragment/createForm.html
+++ b/src/main/resources/templates/study/fragment/createForm.html
@@ -20,8 +20,21 @@
     <div class="form-control">
         <label class="label">
             <span class="label-text">스터디 최대 인원</span>
+            <span th:text="*{capacity}"></span>
         </label>
-        <input type="text" th:field="*{capacity}" placeholder="인원" class="input input-bordered" autofocus />
+        <input type="range" min="1" max="20" class="range range-xs" step="1"
+               autofocus onchange="$(this).keyup();"
+               onkeyup="$(this).prev().children(':last-child').text(this.value.trim());"
+               onpaste="setTimeoutZero(() => $(this).keyup());"
+               th:field="*{capacity}"/>
+
+        <div class="w-full flex justify-between text-xs px-2 mt-3">
+            <span>1</span><span></span><span></span><span></span>
+            <span>5</span><span></span><span></span><span></span><span></span>
+            <span>10</span><span></span><span></span><span></span><span></span>
+            <span>15</span><span></span><span></span><span></span><span></span>
+            <span>20</span>
+        </div>
     </div>
 
 

--- a/src/main/resources/templates/study/fragment/detail/accept.html
+++ b/src/main/resources/templates/study/fragment/detail/accept.html
@@ -1,35 +1,28 @@
 <div th:fragment="accept(myStudy)"
-     class="modal" id="my-modal-23">
+     th:id="'my-modal-' + ${myStudy.id}"
+     class="modal">
 
   <div class="modal-box">
 
-    <!-- 가입요청 경우 활성화 -->
     <h3 th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
         th:text="|${myStudy.member.nickName} 님의 가입 신청|"
         class="font-bold text-lg mb-5"></h3>
 
-    <p th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
-       th:text="${myStudy.msg}"></p>
-
-    <a th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
-       href="#" class="btn mt-4">확인</a>
-
-
-    <!-- 초대한 경우 활성화 -->
     <h3 th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING}"
         th:text="|${myStudy.member.nickName} 님 초대중|"
         class="font-bold text-lg"></h3>
 
     <form th:action="@{/my_study/modify/msg/{id}(id=${myStudy.id})}"
-          th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING}"
           method="post" class="mt-5 mb-5 flex flex-col">
 
 
       <textarea th:text="${myStudy.msg}" name="msg" placeholder="메시지 수정"
+                th:disabled="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING} ? 'disabled'"
                 class="textarea textarea-ghost mb-5 mt-5 w-full"></textarea>
 
 
-      <button class="btn btn-primary">메시지 수정하기</button>
+      <button th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING}"
+              class="btn btn-primary">메시지 수정하기</button>
 
       <a href="#" class="btn mt-4">확인</a>
 

--- a/src/main/resources/templates/study/fragment/detail/accept.html
+++ b/src/main/resources/templates/study/fragment/detail/accept.html
@@ -1,0 +1,38 @@
+<div th:fragment="accept(myStudy)"
+     class="modal" id="my-modal-23">
+
+  <div class="modal-box">
+
+    <!-- 가입요청 경우 활성화 -->
+    <h3 th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
+        th:text="|${myStudy.member.nickName} 님의 가입 신청|"
+        class="font-bold text-lg mb-5"></h3>
+
+    <p th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
+       th:text="${myStudy.msg}"></p>
+
+    <a th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
+       href="#" class="btn mt-4">확인</a>
+
+
+    <!-- 초대한 경우 활성화 -->
+    <h3 th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING}"
+        th:text="|${myStudy.member.nickName} 님 초대중|"
+        class="font-bold text-lg"></h3>
+
+    <form th:action="@{/my_study/modify/msg/{id}(id=${myStudy.id})}"
+          th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING}"
+          method="post" class="mt-5 mb-5 flex flex-col">
+
+
+      <textarea th:text="${myStudy.msg}" name="msg" placeholder="메시지 수정"
+                class="textarea textarea-ghost mb-5 mt-5 w-full"></textarea>
+
+
+      <button class="btn btn-primary">메시지 수정하기</button>
+
+      <a href="#" class="btn mt-4">확인</a>
+
+    </form>
+  </div>
+</div>

--- a/src/main/resources/templates/study/fragment/detail/accept.html
+++ b/src/main/resources/templates/study/fragment/detail/accept.html
@@ -24,8 +24,14 @@
       <button th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).INVITING}"
               class="btn btn-primary">메시지 수정하기</button>
 
-      <a href="#" class="btn mt-4">확인</a>
-
     </form>
+
+    <form th:if="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}"
+          th:action="@{/my_study/study/accept/{id}(id=${myStudy.id})}" method="post">
+      <button class="btn btn-primary mt-4 w-full" type="submit">초대 수락</button>
+    </form>
+
+    <a href="#" class="btn w-full">확인</a>
+
   </div>
 </div>

--- a/src/main/resources/templates/study/fragment/detail/join.html
+++ b/src/main/resources/templates/study/fragment/detail/join.html
@@ -1,0 +1,24 @@
+<div th:fragment="join(study, myStudyJoinForm)"
+     class="modal" id="my-modal-2">
+
+  <div class="modal-box">
+
+
+    <h3 th:text="|${study.name}에 가입하기|"
+        class="font-bold text-lg"></h3>
+
+    <form th:action="@{/my_study/join/{id}(id=${study.id})}"
+          method="post" class="mt-5 mb-5 flex flex-col">
+
+
+      <textarea th:field="${myStudyJoinForm.msg}" placeholder="가입 요청 메시지"
+                class="textarea textarea-ghost mb-5 mt-5 w-full"></textarea>
+
+
+      <button class="btn btn-primary">가입하기</button>
+
+      <a href="#" class="btn mt-4">취소</a>
+
+    </form>
+  </div>
+</div>

--- a/src/main/resources/templates/study/fragment/detail/list.html
+++ b/src/main/resources/templates/study/fragment/detail/list.html
@@ -1,4 +1,4 @@
-<div th:fragment="list (study, list)"
+<div th:fragment="list (study, list, myStudies, pending)"
      class="overflow-x-auto w-[70%] mb-5">
 
     <div class="tabs flex justify-center mb-7">
@@ -12,17 +12,17 @@
                class="tab tab-bordered"
                th:classappend="${list == 'member'} ? 'tab-active' : ''">맴버</a>
 
-            <a th:href="@{/study/detail/req/{id}#list(id=*{study.id})}"
+            <a th:href="@{/study/detail/pending/{id}#list(id=*{study.id})}"
                class="tab tab-bordered"
-               th:classappend="${list == 'req'} ? 'tab-active' : ''">가입 요청</a>
+               th:classappend="${list == 'pending'} ? 'tab-active' : ''">가입 요청</a>
         </div>
 
 
     </div>
 
-    <form th:replace="~{study/fragment/detail/members :: members(${study.myStudies}, ${list})}"></form>
-
     <form th:replace="~{study/fragment/detail/rules :: rules(${study.studyRules}, ${list})}"></form>
 
+    <form th:replace="~{study/fragment/detail/members :: members(${myStudies}, ${list})}"></form>
 
+    <form th:replace="~{study/fragment/detail/pending :: pending(${pending}, ${list})}"></form>
 </div>

--- a/src/main/resources/templates/study/fragment/detail/list.html
+++ b/src/main/resources/templates/study/fragment/detail/list.html
@@ -13,6 +13,7 @@
                th:classappend="${list == 'member'} ? 'tab-active' : ''">맴버</a>
 
             <a th:href="@{/study/detail/pending/{id}#list(id=*{study.id})}"
+               th:if="${@rq.member.nickName eq study.leader}"
                class="tab tab-bordered"
                th:classappend="${list == 'pending'} ? 'tab-active' : ''">가입 요청</a>
         </div>
@@ -24,5 +25,5 @@
 
     <form th:replace="~{study/fragment/detail/members :: members(${myStudies}, ${list})}"></form>
 
-    <form th:replace="~{study/fragment/detail/pending :: pending(${pending}, ${list})}"></form>
+    <form th:replace="~{study/fragment/detail/pending :: pending(${study}, ${pending}, ${list})}"></form>
 </div>

--- a/src/main/resources/templates/study/fragment/detail/pending.html
+++ b/src/main/resources/templates/study/fragment/detail/pending.html
@@ -1,0 +1,61 @@
+<table th:fragment="pending (pending, list)"
+       th:if="${list eq 'pending'}"
+       class="table w-full">
+  <!-- head -->
+  <thead>
+  <tr>
+    <th></th>
+    <th>이름</th>
+    <th>랭킹</th>
+    <th></th>
+  </tr>
+  </thead>
+  <tbody>
+
+  <!-- row -->
+  <tr class="hover"
+      th:each="myStudy , loop : ${pending}">
+
+    <th th:text="${loop.count}"></th>
+
+    <td>
+      <a th:href="@{/member/member/{id}(id=${myStudy.member.id})}">
+        <div class="flex items-center space-x-3">
+          <div class="avatar">
+            <div class="mask mask-squircle w-12 h-12">
+              <img th:src="@{https://avatars.dicebear.com/api/avataaars/__${myStudy.member.profileImg}__.svg}"/>
+            </div>
+          </div>
+          <div>
+            <div th:text="${myStudy.member.nickName}"
+                 class="font-bold">
+            </div>
+            <div th:text="${myStudy.member.about}"
+                 class="text-sm opacity-50">
+            </div>
+          </div>
+        </div>
+      </a>
+    </td>
+
+    <td>
+      <a class="flex justify-center"
+         th:href="@{/member/member/{id}(id=${myStudy.member.id})}">
+        <span th:text="|0|"></span>
+        <br/>
+      </a>
+    </td>
+
+    <td>
+      <a class="link link-primary"
+         href="#my-modal-23">
+        상태
+      </a>
+
+      <div th:replace="~{study/fragment/detail/accept :: accept(${myStudy})}"></div>
+    </td>
+  </tr>
+
+  </tbody>
+
+</table>

--- a/src/main/resources/templates/study/fragment/detail/pending.html
+++ b/src/main/resources/templates/study/fragment/detail/pending.html
@@ -1,61 +1,62 @@
-<table th:fragment="pending (pending, list)"
-       th:if="${list eq 'pending'}"
+<table th:fragment="pending (study, pending, list)"
+       th:if="${list eq 'pending'} and ${@rq.member.nickName eq study.leader}"
        class="table w-full">
-  <!-- head -->
-  <thead>
-  <tr>
-    <th></th>
-    <th>이름</th>
-    <th>랭킹</th>
-    <th></th>
-  </tr>
-  </thead>
-  <tbody>
+    <!-- head -->
+    <thead>
+    <tr>
+        <th></th>
+        <th>이름</th>
+        <th>랭킹</th>
+        <th>상태</th>
+    </tr>
+    </thead>
+    <tbody>
 
-  <!-- row -->
-  <tr class="hover"
-      th:each="myStudy , loop : ${pending}">
+    <!-- row -->
+    <tr class="hover"
+        th:each="myStudy , loop : ${pending}">
 
-    <th th:text="${loop.count}"></th>
+        <th th:text="${loop.count}"></th>
 
-    <td>
-      <a th:href="@{/member/member/{id}(id=${myStudy.member.id})}">
-        <div class="flex items-center space-x-3">
-          <div class="avatar">
-            <div class="mask mask-squircle w-12 h-12">
-              <img th:src="@{https://avatars.dicebear.com/api/avataaars/__${myStudy.member.profileImg}__.svg}"/>
-            </div>
-          </div>
-          <div>
-            <div th:text="${myStudy.member.nickName}"
-                 class="font-bold">
-            </div>
-            <div th:text="${myStudy.member.about}"
-                 class="text-sm opacity-50">
-            </div>
-          </div>
-        </div>
-      </a>
-    </td>
+        <td>
+            <a th:href="@{/member/member/{id}(id=${myStudy.member.id})}">
+                <div class="flex items-center space-x-3">
+                    <div class="avatar">
+                        <div class="mask mask-squircle w-12 h-12">
+                            <img th:src="@{https://avatars.dicebear.com/api/avataaars/__${myStudy.member.profileImg}__.svg}"/>
+                        </div>
+                    </div>
+                    <div>
+                        <div th:text="${myStudy.member.nickName}"
+                             class="font-bold">
+                        </div>
+                        <div th:text="${myStudy.member.about}"
+                             class="text-sm opacity-50">
+                        </div>
+                    </div>
+                </div>
+            </a>
+        </td>
 
-    <td>
-      <a class="flex justify-center"
-         th:href="@{/member/member/{id}(id=${myStudy.member.id})}">
-        <span th:text="|0|"></span>
-        <br/>
-      </a>
-    </td>
+        <td>
+            <a class="flex justify-center"
+               th:href="@{/member/member/{id}(id=${myStudy.member.id})}">
+                <span th:text="|0|"></span>
+                <br/>
+            </a>
+        </td>
 
-    <td>
-      <a class="link link-primary"
-         href="#my-modal-23">
-        상태
-      </a>
+        <td>
+            <a class="link link-primary"
+               th:text="${myStudy.status eq T(com.baeker.baeker.myStudy.StudyStatus).PENDING}? '가입' : '초대'"
+               th:href="@{#my-modal-{id}(id=${myStudy.id})}">>
+                상태
+            </a>
 
-      <div th:replace="~{study/fragment/detail/accept :: accept(${myStudy})}"></div>
-    </td>
-  </tr>
+            <div th:replace="~{study/fragment/detail/accept :: accept(${myStudy})}"></div>
+        </td>
+    </tr>
 
-  </tbody>
+    </tbody>
 
 </table>

--- a/src/main/resources/templates/study/fragment/detail/profile.html
+++ b/src/main/resources/templates/study/fragment/detail/profile.html
@@ -1,4 +1,4 @@
-<div th:fragment="profile (study)"
+<div th:fragment="profile (study, isMyStudy, myStudyJoinForm)"
      class="hero h-80 bg-base-200 flex justify-start">
     <div class="hero-content flex-col lg:flex-row ml-8">
 
@@ -13,19 +13,26 @@
                class="py-6">
             </p>
 
-            <div class="flex gap-5">
-                <span th:if="${@rq.login}">
+            <div th:if="${@rq.login}" class="flex gap-5">
+
+                <span th:if="${study.leader eq @rq.member.getNickName}">
                     <a th:href="@{/studyRule/create/{id}(id=${study.id})}"
-                       th:if="${study.leader eq @rq.member.getNickName}"
                        class="btn btn-primary">규칙 만들기
                     </a>
                 </span>
 
-                <span th:if="${@rq.login}">
+                <span th:if="${study.leader eq @rq.member.getNickName}">
                     <a th:href="@{/study/modify/{id}(id=${study.id})}"
-                       th:if="${study.leader eq @rq.member.getNickName}"
                        class="btn btn-primary">스터디 수정하기
                     </a>
+                </span>
+
+                <span th:unless="${isMyStudy}">
+                    <a href="#my-modal-2"
+                       class="btn btn-primary">스터디 가입하기
+                    </a>
+
+                    <div th:replace="~{study/fragment/detail/join :: join(${study}, ${myStudyJoinForm})}"></div>
                 </span>
             </div>
         </div>

--- a/src/main/resources/templates/study/fragment/detail/profile.html
+++ b/src/main/resources/templates/study/fragment/detail/profile.html
@@ -27,7 +27,7 @@
                     </a>
                 </span>
 
-                <span th:unless="${isMyStudy}">
+                <span th:if="${@rq.member.nickName ne study.leader}">
                     <a href="#my-modal-2"
                        class="btn btn-primary">스터디 가입하기
                     </a>

--- a/src/test/java/com/baeker/baeker/myStudy/MyStudyServiceTest.java
+++ b/src/test/java/com/baeker/baeker/myStudy/MyStudyServiceTest.java
@@ -125,4 +125,22 @@ class MyStudyServiceTest {
         assertThat(invite2.getData().getStatus()).isEqualTo(StudyStatus.MEMBER);
         assertThat(invite2.getData().getMember().getNickName()).isEqualTo("member2");
     }
+
+    @Test
+    void 요청_메시지_수정() {
+        Member leader = create("user", "leader");
+        Study study = createStudy("study", leader);
+
+        Member member1 = create("user1", "member1");
+        RsData<MyStudy> myStudyRs = myStudyService.join(member1, study, "hi");
+        MyStudy myStudy = myStudyRs.getData();
+
+        assertThat(myStudyRs.getResultCode()).isEqualTo("S-1");
+        assertThat(myStudy.getMsg()).isEqualTo("hi");
+
+        // 메시지 수정
+        MyStudy modifyMsg = myStudyService.modifyMsg(myStudy, "hello");
+
+        assertThat(myStudy.getMsg()).isEqualTo("hello");
+    }
 }

--- a/src/test/java/com/baeker/baeker/study/StudyServiceTest.java
+++ b/src/test/java/com/baeker/baeker/study/StudyServiceTest.java
@@ -108,10 +108,4 @@ class StudyServiceTest {
 
         assertThat(modifyStudy.getLeader()).isEqualTo("memberB");
     }
-
-    @Test
-    void name() {
-
-
-    }
 }

--- a/src/test/java/com/baeker/baeker/study/StudyServiceTest.java
+++ b/src/test/java/com/baeker/baeker/study/StudyServiceTest.java
@@ -77,7 +77,7 @@ class StudyServiceTest {
         assertThat(study.getCapacity()).isEqualTo(8);
         assertThat(studies.size()).isEqualTo(1);
 
-        StudyModifyForm form = new StudyModifyForm( "study2", "hello", 10);
+        StudyModifyForm form = new StudyModifyForm( study.getId(), "study2", "hello", 10);
         RsData<Study> modifyRs = studyService.modify(form, study.getId());
         studies = studyService.getAll();
 


### PR DESCRIPTION
## ✏️ 스터디 가입기능 - 완료

- 스터디 상세페이지에서 가입 신청 할 수 있습니다.
- 간단한 가입 요청 메시지를 적을 수 있습니다.

<br> 

## ✏️ 스터디 초대기능 - 완료

- 맴버 프로필에서 초대할 수 있습니다.
- 간단한 초대 메시지를 적을 수 있습니다.

<br> 

### 📍 가입, 초대 확인

- 가입 신청내역은 두군데서 확인 가능합니다.
    - 자신의 프로필의 가입 대기중 탭
    - 스터디 상세페이지의 가입 요청 탭
        - 해당 탭은 리더만 확인할 수 있습니다.

<br> 

### 📍 가입, 초대 메시지 수정

- 가입과 초대 확인 페이지에서 수정 가능합니다.
- 초대는 스터디 리더만, 가입 요청은 본인만 수정할 수 있습니다.
    - 권한이 없으면 텍스트 에어리어와 버튼이 활성화 되지 않습니다.

<br> 

## ✏️ 초대, 가입 승인

- 가입과 초대 확인 페이지에서 승인 가능합니다.
- 초대는 스터디 초대 받은 member 가, 가입 요청은 스터디 리더만 승인할 수 있습니다.
    - 권한이 없으면 텍스트 에어리어와 버튼이 활성화 되지 않습니다.